### PR TITLE
fix cut-off titles in list items (chrome)

### DIFF
--- a/src/app/components/list-item/list-item-component.vue
+++ b/src/app/components/list-item/list-item-component.vue
@@ -45,7 +45,7 @@
 
         display: grid;
         grid-template-columns: 20% 80%;
-        grid-template-rows: 70% 30%;
+        grid-template-rows: 66% 33%;
 
         cursor: pointer;
     }

--- a/src/app/components/list-item/student-list-item.vue
+++ b/src/app/components/list-item/student-list-item.vue
@@ -59,7 +59,7 @@
 
         display: grid;
         grid-template-columns: 20% 80%;
-        grid-template-rows: 70% 30%;
+        grid-template-rows: 66% 33%;
 
         cursor: pointer;
     }


### PR DESCRIPTION
quick and dirty